### PR TITLE
Better parsing of malformed records. Changed keys in returned dict to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,57 +3,64 @@ A very simple CEF parser for Python 2/3
 
 I originally wrote this because I wasn't able to find very many good Python CEF parsers out there.  I did find [one by Sooshie](https://github.com/sooshie/cef_parser) that got me started (thanks for sharing, sir!), but I elected to produce my own.  
 
-The `parse` function takes a string containing a single CEF record and returns a dict containing the following keys, as defined in the [CEF format documentation](https://www.protect724.hpe.com/docs/DOC-1072):
+The `parse` function takes a string containing a single CEF record and returns a dict containing the following keys, as defined in the [CEF format documentation](https://community.microfocus.com/t5/ArcSight-Connectors/ArcSight-Common-Event-Format-CEF-Implementation-Standard/ta-p/1645557):
 
 * CEFVersion
 * DeviceVendor
 * DeviceVersion
 * DeviceEventClassID
-* DeviceName
-* DeviceSeverity
+* Name
+* Severity
 
 If there are any `key=value` pairs in the "extensions" section (and face it, pretty much every CEF record has these), they'll also be in the dict, with the dict key name the same as the CEF record's key name. If it could not recognize any CEF data, the `parse` function will return `None`.
 
+_NOTE: Versions 1.10 and earlier used 'DeviceName' and 'DeviceSeverity' instead of just 'Name' and 'Severity'. Those old keys are still present in the returned dictionary for backwards-compatibility reasons, but are likely to be removed in the future without warning._
 
 ## Example Usage
 Parsing a well-formatted CEF record
 
-    >>> import pycef
-    >>> cef = 'CEF:0|pycef|python CEF tests|1|2|Test event 1|3| field1=value1 field2=value2 field3=value3'
-    >>> d = pycef.parse(cef)
-    >>> d
-    {'DeviceVendor': 'pycef', 'DeviceProduct': 'python CEF tests', 'DeviceVersion': '1', 'DeviceEventClassID': '2', 'DeviceName': 'Test event 1', 'DeviceSeverity': '3', 'CEFVersion': '0', 'field1': 'value1', 'field2': 'value2', 'field3': 'value3'}
+```python
+>>> import pycef
+>>> cef = 'CEF:0|pycef|python CEF tests|1|2|Test event 1|3| field1=value1 field2=value2 field3=value3'
+>>> d = pycef.parse(cef)
+>>> d
+{'DeviceVendor': 'pycef', 'DeviceProduct': 'python CEF tests', 'DeviceVersion': '1', 'DeviceEventClassID': '2', 'Name': 'Test event 1', 'Severity': '3', 'CEFVersion': '0', 'field1': 'value1', 'field2': 'value2', 'field3': 'value3'}
+```
 
 Parsing a line of CEF from a source with header junk at the front (NOTE: this isn't specific to syslog headers as in the example. The parser just starts wherever 'CEF:0' is found):
 
-    >>> import pycef
-    >>> cef_syslog = 'Nov 16 21:24:18 arcsightfwd.davidbianco.io CEF:0|pycef|python CEF tests|1|2|Test event 1|3| field1=value1 field2=value2 field3=value3'
-    >>> d = pycef.parse(cef_syslog)
-    >>> d
-    {'DeviceVendor': 'pycef', 'DeviceProduct': 'python CEF tests', 'DeviceVersion': '1', 'DeviceEventClassID': '2', 'DeviceName': 'Test event 1', 'DeviceSeverity': '3', 'CEFVersion': '0', 'field1': 'value1', 'field2': 'value2', 'field3': 'value3'}
+```python
+>>> import pycef
+>>> cef_syslog = 'Nov 16 21:24:18 arcsightfwd.davidbianco.io CEF:0|pycef|python CEF tests|1|2|Test event 1|3| field1=value1 field2=value2 field3=value3'
+>>> d = pycef.parse(cef_syslog)
+>>> d
+{'DeviceVendor': 'pycef', 'DeviceProduct': 'python CEF tests', 'DeviceVersion': '1', 'DeviceEventClassID': '2', 'Name': 'Test event 1', 'Severity': '3', 'CEFVersion': '0', 'field1': 'value1', 'field2': 'value2', 'field3': 'value3'}
+```
 
 ## Logging
 `Pycef` uses the standard Python `logging` module.  By default, you will not see any logs, but you can easily configure them within your own application.  Here's an example:
 
-    import logging
+```python
+import logging
 
-    # We log with the name 'pycef'
-    logger = logging.getLogger('pycef')
+# We log with the name 'pycef'
+logger = logging.getLogger('pycef')
 
-    # set log level to DEBUG to get the most verbose output
-    logger.setLevel(logging.DEBUG)
+# set log level to DEBUG to get the most verbose output
+logger.setLevel(logging.DEBUG)
 
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+logger.addHandler(ch)
 
-    # well-formatted CEF data will log the parsed values at DEBUG level
-    cef = 'CEF:0|pycef|python CEF tests|1|2|Test event 1|3| field1=value1 field2=value2 field3=value3'
-    d = pycef.parse(cef)
-    2018-11-23 08:49:39,827 - pycef - DEBUG - Returning values: {'DeviceVendor': 'pycef', 'DeviceProduct': 'python CEF tests', 'DeviceVersion': '1', 'DeviceEventClassID': '2', 'DeviceName': 'Test event 1', 'DeviceSeverity': '3', 'CEFVersion': '0', 'field1': 'value1', 'field2': 'value2', 'field3': 'value3'}
+# well-formatted CEF data will log the parsed values at DEBUG level
+cef = 'CEF:0|pycef|python CEF tests|1|2|Test event 1|3| field1=value1 field2=value2 field3=value3'
+d = pycef.parse(cef)
+2018-11-23 08:49:39,827 - pycef - DEBUG - Returning values: {'DeviceVendor': 'pycef', 'DeviceProduct': 'python CEF tests', 'DeviceVersion': '1', 'DeviceEventClassID': '2', 'Name': 'Test event 1', 'Severity': '3', 'CEFVersion': '0', 'field1': 'value1', 'field2': 'value2', 'field3': 'value3'}
 
-    # Parse errors in the data will log at WARNING level
-    pycef.parse('kjlk')
-    2018-11-23 08:47:42,853 - pycef - WARNING - Could not parse record. Is it valid CEF format?
+# Parse errors in the data will log at WARNING level
+pycef.parse('kjlk')
+2018-11-23 08:47:42,853 - pycef - WARNING - Could not parse record. Is it valid CEF format?
+```

--- a/pycef/__init__.py
+++ b/pycef/__init__.py
@@ -35,14 +35,24 @@ def parse(str_input):
         # though.
         spl = re.split(r'(?<!\\)\|', header)
 
+        # If the input entry had any blanks in the required headers, that's wrong
+        # and we should return.  Note we explicitly don't check the last item in the 
+        # split list becuase the header ends in a '|' which means the last item
+        # will always be an empty string (it doesn't exist, but the delimiter does).
+        if "" in spl[0:-1]:
+            logger.warning(f'Blank field(s) in CEF header. Is it valid CEF format?')
+            return None
+
         # Since these values are set by their position in the header, it's
         # easy to know which is which.
         values["DeviceVendor"] = spl[1]
         values["DeviceProduct"] = spl[2]
         values["DeviceVersion"] = spl[3]
         values["DeviceEventClassID"] = spl[4]
+        values["Name"] = spl[5]
         values["DeviceName"] = spl[5]
         if len(spl) > 6:
+            values["Severity"] = spl[6]
             values["DeviceSeverity"] = spl[6]
 
         # The first value is actually the CEF version, formatted like

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,10 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pycef',
-      version='1.10',
+      version='1.11',
       description='A very simple CEF parser.',
       long_description=long_description,
+      long_description_content_type="text/markdown",
       url='https://github.com/DavidJBianco/pycef',
       author='David J. Bianco',
       author_email='davidjbianco@gmail.com',

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -4,7 +4,7 @@ import pycef
 import json
 from unittest import TestCase
 
-LINE1_REF = dict(DeviceName="Test pipe event 1", field1="value1", field2="value2|more", field3="value3", DeviceVendor="pycef", CEFVersion="0", DeviceSeverity="3", DeviceEventClassID="2", DeviceProduct="python CEF tests", DeviceVersion="1")
+LINE1_REF = dict(Name="Test pipe event 1", DeviceName="Test pipe event 1", field1="value1", field2="value2|more", field3="value3", DeviceVendor="pycef", CEFVersion="0", Severity="3", DeviceSeverity="3", DeviceEventClassID="2", DeviceProduct="python CEF tests", DeviceVersion="1")
 
 REFERENCE_DATA = [LINE1_REF]
 

--- a/tests/test_pycef.py
+++ b/tests/test_pycef.py
@@ -4,13 +4,16 @@ import pycef
 import json
 from unittest import TestCase
 
-CEF1_REF = dict(DeviceName="Test event 1", field1="value1", field2="value2", field3="value3", DeviceVendor="pycef", CEFVersion="0", DeviceSeverity="3", DeviceEventClassID="2", DeviceProduct="python CEF tests", DeviceVersion="1")
-CEF2_REF = dict(DeviceName="Test event 2", field6="value6", DeviceVendor="pycef", field4="value4", field5="value5", CEFVersion="0", DeviceSeverity="6", DeviceEventClassID="5", DeviceProduct="python CEF tests", DeviceVersion="4")
-CEF3_REF = dict(DeviceName="Test event 3", field8="value8", field9="value9", DeviceVendor="pycef", CEFVersion="0", DeviceSeverity="9", DeviceEventClassID="8", DeviceProduct="python CEF tests", DeviceVersion="7")
+CEF1_REF = dict(Name="Test event 1", DeviceName="Test event 1", field1="value1", field2="value2", field3="value3",
+                DeviceVendor="pycef", CEFVersion="0", Severity="3", DeviceSeverity="3", DeviceEventClassID="2", DeviceProduct="python CEF tests", DeviceVersion="1")
+CEF2_REF = dict(Name="Test event 2", DeviceName="Test event 2", field6="value6", DeviceVendor="pycef", field4="value4",
+                field5="value5", CEFVersion="0", Severity="6", DeviceSeverity="6", DeviceEventClassID="5", DeviceProduct="python CEF tests", DeviceVersion="4")
+CEF3_REF = dict(Name="Test event 3", DeviceName="Test event 3", field8="value8", field9="value9", DeviceVendor="pycef",
+                CEFVersion="0", Severity="9", DeviceSeverity="9", DeviceEventClassID="8", DeviceProduct="python CEF tests", DeviceVersion="7")
 CEF4_REF = None
 CEF_REFERENCE_DATA = [CEF4_REF, CEF3_REF, CEF2_REF, CEF1_REF]
 
-SYSLOG1_REF = dict(DeviceName="Test event 1", field1="value1", field2="value2", field3="value3", DeviceVendor="pycef", CEFVersion="0", DeviceSeverity="3", DeviceEventClassID="2", DeviceProduct="python CEF tests", DeviceVersion="1")
+SYSLOG1_REF = dict(DeviceName="Test event 1", Name="Test event 1", field1="value1", field2="value2", field3="value3", DeviceVendor="pycef", CEFVersion="0", Severity="3", DeviceSeverity="3", DeviceEventClassID="2", DeviceProduct="python CEF tests", DeviceVersion="1")
 SYSLOG_REFERENCE_DATA = [SYSLOG1_REF]
 
 class TestPyCEF(TestCase):
@@ -34,3 +37,14 @@ class TestPyCEF(TestCase):
                 d = pycef.parse(l)
                 d_ref = SYSLOG_REFERENCE_DATA.pop()
                 self.assertDictEqual(d, d_ref)
+
+    def test_missing_header_value(self):
+        '''
+        Test that we don't try to incorrectly parse a record where one or more of the
+        CEF header values are missing.
+        '''
+        with open("tests/testdata-missing-header-values.cef", "r") as f:
+            for l in f.readlines():
+                d = pycef.parse(l) 
+
+                self.assertIsNone(d, "Tried to parse a record with one or more missing CEF header values.")

--- a/tests/testdata-missing-header-values.cef
+++ b/tests/testdata-missing-header-values.cef
@@ -1,0 +1,8 @@
+CEF:0||python CEF tests|1|2|Test event 1|3| field1=value1 field2=value2 field3=value3
+CEF:0|pycef||4|5|Test event 2|6| field4=value4 field5=value5 field6=value6
+CEF:0|pycef|python CEF tests||8|Test event 3|9| field9=value9 field8=value8 field9=value9
+CEF:0|pycef|python CEF tests|7||Test event 3|9| field9=value9 field8=value8 field9=value9
+CEF:0|pycef|python CEF tests|7|8||9| field9=value9 field8=value8 field9=value9
+CEF:0|pycef|python CEF tests|7|8|Test event 3|| field9=value9 field8=value8 field9=value9
+CEF:0||python CEF tests|7||Test event 3|9| field9=value9 field8=value8 field9=value9
+CEF:0||||||| field9=value9 field8=value8 field9=value9


### PR DESCRIPTION
… conform to CEF spec.

* CEF records with blanks in the required headers (i.e., "||") now correctly return None
  when sent to parse().  If logging is enabled, a warning is also generated.
* In the past, we used to return 'DeviceName' and 'DeviceSeverity' keys when parsing records,
  but the spec actually just calls these 'Name' and 'Severity', so we do now, too.  The old
  keys are also present for backwards-compatibility.
* Tests and documentation have been updated to reflect these changes.